### PR TITLE
Rate limiting

### DIFF
--- a/scraper/src/scraper/github_client.clj
+++ b/scraper/src/scraper/github_client.clj
@@ -7,7 +7,7 @@
 (def github-auth [(env :github-username) (env :github-token)])
 (def github-base-path "https://api.github.com")
 
-(defn qs-pair
+(defn- qs-pair
   [pair-str]
   (let [[key value] (split pair-str #"=")]
     [(keyword key) value]))
@@ -21,7 +21,7 @@
           query (apply hash-map (mapcat qs-pair (split qs #"&")))]
       {:url url :query query})))
 
-(defn rate-limit
+(defn- rate-limit
   [headers]
   (if (and (:x-ratelimit-remaining headers) (:x-ratelimit-reset headers))
     {:remaining (Integer/parseInt (:x-ratelimit-remaining headers))
@@ -41,57 +41,61 @@
        :next-page (next-page (:Link headers))
        :rate-limit (rate-limit headers)}))
 
-(defn time-now []
+(defn- time-now []
   (System/currentTimeMillis))
 
-(defn calculate-delay
+(defn- calculate-delay
   "Calculate delay necessary to stay within the rate limit"
   [now {remaining :remaining reset :reset}]
   (if (and now remaining reset)
     (quot (- reset now) remaining)
     0))
 
+(defn- rate-limit-in-ms
+  [rate-limit-in-s]
+  (if (:reset rate-limit-in-s)
+    {:remaining (:remaining rate-limit-in-s) :reset (* 1000 (:reset rate-limit-in-s))}
+    {}))
+
 (defn with-rate-limiting
-  "Makes a function asynchronous by running it on a thread and using core.async channels to give
-  it inputs and take outputs. Takes the input channel as argument."
+  "Makes a function asynchronous by running it on a separate thread passing inputs and outputs
+  over async channels. Assumes the function returns a map with a :rate-limit key containing
+  the current rate limits. NOTE The resulting function is thread blocking!"
   [fun]
   (let [input-channel (chan)]
     (thread ; spin off the worker thread
       (loop [{:keys [args ch]} (<!! input-channel)
              limits {}]
-        (if args
-          (do
-            (let [delay (calculate-delay (time-now) limits)]
-              (println "- Waiting" delay "for rate limiting" limits)
-              (if delay
-                (<!! (timeout delay)))
-              (let [{rate-limit-info :rate-limit :as ret-val} (apply fun args)
-                    new-limit (if (and limits (:reset rate-limit-info)) {:remaining (:remaining rate-limit-info) :reset (* 1000 (:reset rate-limit-info))} {})]
-                (>!! ch ret-val)
-                (recur (<!! input-channel) new-limit)))))))
-    (fn [& args]
-      (let [out-ch (chan)] ; for each call create an channel to receive the result
+        (if args ; stop when the channel closes
+          (let [delay (calculate-delay (time-now) limits)]
+            (println "Pausing for" delay "ms to fit the rate limit" limits "...")
+            (if delay (<!! (timeout delay)))
+            (let [{rate-limit-info :rate-limit :as ret-val} (apply fun args)
+                  new-rate-limit-info (rate-limit-in-ms rate-limit-info)]
+              (>!! ch ret-val)
+              (recur (<!! input-channel) new-rate-limit-info))))))
+    (fn [& args] ; original function proxy on the current thread
+      (let [out-ch (chan)]
         (>!! input-channel {:args args :ch out-ch})
         (<!! out-ch)))))
-
-(def perform-request-with-rate-limit (with-rate-limiting perform-request)) ; blocking
 
 (defn request
   "run a github request while respecting the rate limit and follow pagination if necessary"
   [http-get]
-  (fn [initial-req]
-    (let [{path :path} initial-req
-          url (str github-base-path path)
-          {:keys [body next-page]} (perform-request-with-rate-limit http-get (assoc initial-req :url url))]
-      (if (not next-page)
-        body
-        (loop [items body
-               req (merge initial-req next-page)]
-          (let [{:keys [body next-page]} (perform-request-with-rate-limit http-get req)
-                new-items (into [] (concat items body))]
-            (if (not next-page)
-              new-items
-              (recur new-items (merge req next-page)))))))))
+  (let [run-req (with-rate-limiting perform-request)]
+    (fn [initial-req]
+      (let [{path :path} initial-req
+            url (str github-base-path path)
+            {:keys [body next-page]} (run-req http-get (assoc initial-req :url url))]
+        (if (not next-page)
+          body
+          (loop [items body
+                 req (merge initial-req next-page)]
+            (let [{:keys [body next-page]} (run-req http-get req)
+                  new-items (into [] (concat items body))]
+              (if (not next-page)
+                new-items
+                (recur new-items (merge req next-page))))))))))
 
 (defn org-members
   "fetches members of an organisation"
@@ -107,7 +111,7 @@
     (let [res (gh {:path (str "/users/" user "/orgs") :query {:per_page 100}})]
       (into [] (map (fn [it] {:org (:login it) :user user}) res)))))
 
-(defn parse-repos
+(defn- parse-repos
   [user repos]
   (let [tx (comp
              (filter #(not (or (:private %) (:fork %))))
@@ -128,7 +132,7 @@
     (let [res (gh {:path (str "/orgs/" org "/repos") :query {:per_page 100 :type "public"}})]
       (parse-repos user res))))
 
-(defn repo-from-url
+(defn- repo-from-url
   [url]
   (clojure.string/join "/"
     (-> url
@@ -138,7 +142,7 @@
       (subvec 0 2)
       (reverse))))
 
-(defn parse-issue
+(defn- parse-issue
   [issue]
   (let [repo (repo-from-url (:repository_url issue))
         user (:login (:user issue))
@@ -157,7 +161,7 @@
           ]
       (into [] (map parse-issue (:items res))))))
 
-(defn parse-commit
+(defn- parse-commit
   [user commit]
   {:user user
    :commit {:title (:message (:commit commit))

--- a/scraper/test/scraper/github_client_test.clj
+++ b/scraper/test/scraper/github_client_test.clj
@@ -17,9 +17,8 @@
 
 (deftest does-request
   "client sends requests and parses responses"
-  (let [req {:method :get :path "/foo" :query {:page 2}}
-        client (gh/request basic-get)
-        res (client req)]
+  (let [client (gh/request basic-get)
+        res (client {:path "/foo" :query {:page 2}})]
     (is (= res {:url "https://api.github.com/foo" :auth gh/github-auth}))))
 
 (def ten-minutes-from-now (+ (* 10 60) (quot (System/currentTimeMillis) 1000)))
@@ -41,11 +40,10 @@
 
 (deftest perform-request
   "client performs a single request returning body and relevant header information"
-  (let [req {:url "https://api.github.com/foo"}
-        res (gh/perform-request paged-get req)]
+  (let [res (gh/perform-request paged-get :core "https://api.github.com/foo")]
     (is (= (:body res) [{:url "https://api.github.com/foo"}]))
     (is (= (:next-page res) {:url "https://api.github.com/bar" :query {:page "2"}}))
-    (is (= (:rate-limit res) {:remaining 6000 :reset ten-minutes-from-now}))))
+    (is (= (:rate-limit res) {:scope :core :remaining 6000 :reset ten-minutes-from-now}))))
 
 (deftest follows-pagination
   "client follows pagination and augments the collection"


### PR DESCRIPTION
This adds support for running the Github request at most at the rate the API allows by calculating the minimum delay between requests based on the current budget and the reset time (dividing the remaining time by the number of requests). It also respects the scope of the rate limit (`core` or `search`).

To make sure we don't block the main thread while waiting for the rate limit the network I/O is done on a separate worker thread. At the moment, the proxy function to dispatch to the worker thread **still blocks** the thread it's run on waiting for a response (but technically, we could run multiple workers if the rate limit was lower, I admit I did that more to play with `core.async` than anything else:)). In order to get fully async streaming behaviour, we need to dispatch the github client function calls on their own thread(s) and wait for their results in go blocks. That should give us fully streaming behaviour. Not sure how much that is necessary if I'm honest...

The implementation is slightly messy and pretty coupled to the Github API, I'd love to improve it, but I'm too tired to see how right now.
# to do
- [x] rate limit the requests
- [x] adapt the rate limit to what the github response says
- [x] support multiple rate limit scopes
- [x] better logging
